### PR TITLE
27 fix numpy version conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ To learn more about how the model is designed, check the specifications linked a
 ## Prerequisites
 
 ```
-numpy>=1.23.1
-pandas>=1.4.3
-requests>=2.28.1
+numpy>=1.22
+pandas>=1.4
+requests>=2.28
 matplotlib>=3.5.2
 seaborn>=0.11.2
 ```

--- a/mechafil/__init__.py
+++ b/mechafil/__init__.py
@@ -1,6 +1,6 @@
 """MechaFIL: Mechanistic model for the Filecoin Economy"""
 
-__version__ = "1.2"
+__version__ = "1.7"
 __author__ = "Maria Silva <misilva73@gmail.com>, Tom Mellan <t.mellan@imperial.ac.uk>, Kiran Karra <kiran.karra@gmail.com>"
 __all__ = []
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mechaFIL",
-    version="1.6",
+    version="1.7",
     author="Maria Silva, Tom Mellan, Kiran Karra",
     author_email="misilva73@gmail.com, t.mellan@imperial.ac.uk, kiran.karra@gmail.com",
     description="Mechanistic model for the Filecoin Economy",
@@ -15,8 +15,8 @@ setuptools.setup(
         "Documentation": "https://github.com/protocol/filecoin-mecha-twin",
         "Source": "https://github.com/protocol/filecoin-mecha-twin",
     },
-    packages=['mechafil'],
-    install_requires=["numpy>=1.23.1", "pandas>=1.4.3", "requests>=2.28.1"],
+    packages=["mechafil"],
+    install_requires=["numpy>=1.22", "pandas>=1.4", "requests>=2.28"],
     python_requires=">=3.8",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
scipy 1.7.3 requires numpy<1.23.0, which is creating some issues with Google Collab imports. 

Changing the required version to 1.22 is not expected to break anything, while fixing the import warnings